### PR TITLE
Add array support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ Currently oster supports basic data types but getting support for user defined t
 
 - rune
 - arbitrary pointers
-- arrays
 - slices
 - user/stdlib defined structs
 - user/stdlib defined interfaces
@@ -55,7 +54,7 @@ Currently oster supports basic data types but getting support for user defined t
 
 ## Dependencies
 
-- bcc
+- [bcc](https://github.com/iovisor/bcc/blob/master/INSTALL.md)
 - linux kernel version > 4.14 (please make bug reports if your kernel version doesn't work)
 
 ## Build

--- a/cmd/oster/load_uprobe.go
+++ b/cmd/oster/load_uprobe.go
@@ -29,12 +29,29 @@ const bpfProgramTextTemplate = `
 		unsigned int i_{{$arg_element.VariableName}};
 		void* loopAddr_{{$arg_element.VariableName}} = stackAddr+{{$arg_element.StartingOffset}};
 		for (i_{{$arg_element.VariableName}} = 0; i_{{$arg_element.VariableName}} < {{$arg_element.ArrayLength}}; i_{{$arg_element.VariableName}}++) {
+			{{if ne $arg_element.CType "char *" }} 
 			{{$arg_element.CType}} {{$arg_element.VariableName}};
 			bpf_probe_read(&{{$arg_element.VariableName}}, sizeof({{$arg_element.VariableName}}), loopAddr_{{$arg_element.VariableName}}); 
 			events.perf_submit(ctx, &{{$arg_element.VariableName}}, sizeof({{$arg_element.VariableName}}));
 			loopAddr_{{$arg_element.VariableName}} += {{$arg_element.TypeSize}};
+			{{else}}
+			unsigned long {{$arg_element.VariableName}}_length;
+			bpf_probe_read(&{{$arg_element.VariableName}}_length, sizeof({{$arg_element.VariableName}}_length), loopAddr_{{$arg_element.VariableName}}+8);
+			if ({{$arg_element.VariableName}}_length > 16 ) {
+				{{$arg_element.VariableName}}_length = 16;
+			}
+			unsigned int str_length = (unsigned int){{$arg_element.VariableName}}_length;
+			
+			// use long double to have up to a 16 character string by reading in the raw bytes
+			long double* {{$arg_element.VariableName}}_ptr;
+			long double  {{$arg_element.VariableName}};
+			bpf_probe_read(&{{$arg_element.VariableName}}_ptr, sizeof({{$arg_element.VariableName}}_ptr), loopAddr_{{$arg_element.VariableName}});
+			bpf_probe_read(&{{$arg_element.VariableName}}, sizeof({{$arg_element.VariableName}}), {{$arg_element.VariableName}}_ptr);
+		
+			events.perf_submit(ctx, &{{$arg_element.VariableName}}, str_length);
+			loopAddr_{{$arg_element.VariableName}} += 16;
+			{{end}}
 		}
-
 		{{else if eq $arg_element.CType "char *" }}
 		unsigned long {{$arg_element.VariableName}}_length;
 		bpf_probe_read(&{{$arg_element.VariableName}}_length, sizeof({{$arg_element.VariableName}}_length), stackAddr+{{$arg_element.StartingOffset}}+8);
@@ -49,13 +66,11 @@ const bpfProgramTextTemplate = `
 		bpf_probe_read(&{{$arg_element.VariableName}}_ptr, sizeof({{$arg_element.VariableName}}_ptr), stackAddr+{{$arg_element.StartingOffset}});
 		bpf_probe_read(&{{$arg_element.VariableName}}, sizeof({{$arg_element.VariableName}}), {{$arg_element.VariableName}}_ptr);
 		events.perf_submit(ctx, &{{$arg_element.VariableName}}, str_length);
-		
 		{{- else }}
 		{{$arg_element.CType}} {{$arg_element.VariableName}};
 		bpf_probe_read(&{{$arg_element.VariableName}}, sizeof({{$arg_element.VariableName}}), stackAddr+{{$arg_element.StartingOffset}}); 
 		events.perf_submit(ctx, &{{$arg_element.VariableName}}, sizeof({{$arg_element.VariableName}}));
 		{{- end}}
-		
 		{{end}}
 		return 0;
 	}
@@ -136,7 +151,7 @@ func loadUprobeAndBPFModule(context *traceContext) error {
 					arrayValueString = arrayValueString + ", " + valueString
 				}
 				outputValue = output{
-					Type:  goTypeToString[dataTypeOfValue],
+					Type:  goTypeToString[dataTypeOfValue] + "_ARRAY",
 					Value: arrayValueString,
 				}
 

--- a/cmd/oster/load_uprobe.go
+++ b/cmd/oster/load_uprobe.go
@@ -25,13 +25,13 @@ const bpfProgramTextTemplate = `
 
 		{{if gt $arg_element.ArrayLength 0}}
 
-		unsigned int i;
-		void* loopAddr = stackAddr+{{$arg_element.StartingOffset}};
-		for (i = 0; i < {{$arg_element.ArrayLength}}; i++) {
+		unsigned int i_{{$arg_element.VariableName}};
+		void* loopAddr_{{$arg_element.VariableName}} = stackAddr+{{$arg_element.StartingOffset}};
+		for (i_{{$arg_element.VariableName}} = 0; i_{{$arg_element.VariableName}} < {{$arg_element.ArrayLength}}; i_{{$arg_element.VariableName}}++) {
 			{{$arg_element.CType}} {{$arg_element.VariableName}};
-			bpf_probe_read(&{{$arg_element.VariableName}}, sizeof({{$arg_element.VariableName}}), loopAddr); 
+			bpf_probe_read(&{{$arg_element.VariableName}}, sizeof({{$arg_element.VariableName}}), loopAddr_{{$arg_element.VariableName}}); 
 			events.perf_submit(ctx, &{{$arg_element.VariableName}}, sizeof({{$arg_element.VariableName}}));
-			loopAddr += {{$arg_element.TypeSize}}; //FIXME:
+			loopAddr_{{$arg_element.VariableName}} += {{$arg_element.TypeSize}};
 		}
 
 		{{else if eq $arg_element.CType "char *" }}
@@ -121,6 +121,12 @@ func loadUprobeAndBPFModule(context *traceContext) error {
 
 			// based on order of value coming in determine what type it is for interpretation
 			dataTypeOfValue = context.Arguments[index].goType
+
+			if context.Arguments[index].ArrayLength > 0 {
+				//TODO:
+				// Read from channel ArrayLength - 1 more times, combine all the values into a single string,
+				// and set the type string to array of gotype
+			}
 
 			valueString := interpretDataByType(value, dataTypeOfValue)
 

--- a/cmd/oster/load_uprobe.go
+++ b/cmd/oster/load_uprobe.go
@@ -24,7 +24,15 @@ const bpfProgramTextTemplate = `
 		{{range $arg_index, $arg_element := .Arguments}}
 
 		{{if gt $arg_element.ArrayLength 0}}
-		// TODO: eBPF code for reading array
+
+		unsigned int i;
+		void* loopAddr = stackAddr+{{$arg_element.StartingOffset}};
+		for (i = 0; i < {{$arg_element.ArrayLength}}; i++) {
+			{{$arg_element.CType}} {{$arg_element.VariableName}};
+			bpf_probe_read(&{{$arg_element.VariableName}}, sizeof({{$arg_element.VariableName}}), loopAddr); 
+			events.perf_submit(ctx, &{{$arg_element.VariableName}}, sizeof({{$arg_element.VariableName}}));
+			loopAddr += {{$arg_element.TypeSize}}; //FIXME:
+		}
 
 		{{else if eq $arg_element.CType "char *" }}
 		unsigned long {{$arg_element.VariableName}}_length;

--- a/cmd/oster/stack_offsets.go
+++ b/cmd/oster/stack_offsets.go
@@ -31,6 +31,16 @@ func determineStackOffsets(context *traceContext) error {
 		}
 
 		context.Arguments[i].StartingOffset = currentIndex
+
+		if context.Arguments[i].ArrayLength > 0 {
+			if context.Arguments[i].goType == STRING {
+				typeSize = 16
+			}
+			currentIndex += typeSize * context.Arguments[i].ArrayLength
+			bytesInCurrentWindow += (typeSize * context.Arguments[i].ArrayLength) % windowSize
+			continue
+		}
+
 		currentIndex += typeSize
 		bytesInCurrentWindow += typeSize
 
@@ -38,6 +48,7 @@ func determineStackOffsets(context *traceContext) error {
 		if context.Arguments[i].goType == STRING {
 			currentIndex += 8
 		}
+
 	}
 
 	return nil

--- a/cmd/oster/stack_offsets.go
+++ b/cmd/oster/stack_offsets.go
@@ -23,6 +23,7 @@ func determineStackOffsets(context *traceContext) error {
 
 	for i := range context.Arguments {
 		typeSize := goTypeToSizeInBytes[context.Arguments[i].goType]
+		context.Arguments[i].TypeSize = typeSize
 
 		if typeSize+bytesInCurrentWindow > windowSize {
 			// Doesn't fit, move index ahead for padding, clear current window

--- a/cmd/print_stack/observations/slices.md
+++ b/cmd/print_stack/observations/slices.md
@@ -1,0 +1,289 @@
+https://blog.golang.org/go-slices-usage-and-internals
+
+Slices are passed by the following header:
+
+
+type SliceHeader struct {
+    Data uintptr
+    Len  int
+    Cap  int
+}
+
+## Int64 slice:
+
+```
+package main
+
+//go:noinline
+func test_function(a []int64) {}
+
+func main() {
+	test_function([]int64{1, 2, 3, 5})
+}
+```
+
+```
+SP+0:	149 (0x95)
+SP+1:	35 (0x23)
+SP+2:	69 (0x45)
+SP+3:	0 (0x0)
+SP+4:	0 (0x0)
+SP+5:	0 (0x0)
+SP+6:	0 (0x0)
+SP+7:	0 (0x0)
+
+SP+8:	48 (0x30)
+SP+9:	199 (0xc7)
+SP+10:	4 (0x4)
+SP+11:	0 (0x0)
+SP+12:	192 (0xc0)
+SP+13:	0 (0x0)
+SP+14:	0 (0x0)
+SP+15:	0 (0x0)
+
+SP+16:	4 (0x4)
+SP+17:	0 (0x0)
+SP+18:	0 (0x0)
+SP+19:	0 (0x0)
+SP+20:	0 (0x0)
+SP+21:	0 (0x0)
+SP+22:	0 (0x0)
+SP+23:	0 (0x0)
+
+SP+24:	4 (0x4)
+SP+25:	0 (0x0)
+SP+26:	0 (0x0)
+SP+27:	0 (0x0)
+SP+28:	0 (0x0)
+SP+29:	0 (0x0)
+SP+30:	0 (0x0)
+SP+31:	0 (0x0)
+
+SP+32:	1 (0x1)
+SP+33:	0 (0x0)
+SP+34:	0 (0x0)
+SP+35:	0 (0x0)
+SP+36:	0 (0x0)
+SP+37:	0 (0x0)
+SP+38:	0 (0x0)
+SP+39:	0 (0x0)
+
+SP+40:	2 (0x2)
+SP+41:	0 (0x0)
+SP+42:	0 (0x0)
+SP+43:	0 (0x0)
+SP+44:	0 (0x0)
+SP+45:	0 (0x0)
+SP+46:	0 (0x0)
+SP+47:	0 (0x0)
+
+SP+48:	3 (0x3)
+SP+49:	0 (0x0)
+SP+50:	0 (0x0)
+SP+51:	0 (0x0)
+SP+52:	0 (0x0)
+SP+53:	0 (0x0)
+SP+54:	0 (0x0)
+SP+55:	0 (0x0)
+
+SP+56:	5 (0x5)
+SP+57:	0 (0x0)
+SP+58:	0 (0x0)
+SP+59:	0 (0x0)
+SP+60:	0 (0x0)
+SP+61:	0 (0x0)
+SP+62:	0 (0x0)
+SP+63:	0 (0x0)
+```
+
+## Int32 slice:
+
+```
+func test_function(a []int32) {}
+
+func main() {
+	test_function([]int32{1, 2, 3, 5})
+}
+```
+
+```
+SP+0:	137 (0x89)
+SP+1:	35 (0x23)
+SP+2:	69 (0x45)
+SP+3:	0 (0x0)
+SP+4:	0 (0x0)
+SP+5:	0 (0x0)
+SP+6:	0 (0x0)
+SP+7:	0 (0x0)
+
+SP+8:	64 (0x40)
+SP+9:	199 (0xc7)
+SP+10:	4 (0x4)
+SP+11:	0 (0x0)
+SP+12:	192 (0xc0)
+SP+13:	0 (0x0)
+SP+14:	0 (0x0)
+SP+15:	0 (0x0)
+
+SP+16:	4 (0x4)
+SP+17:	0 (0x0)
+SP+18:	0 (0x0)
+SP+19:	0 (0x0)
+SP+20:	0 (0x0)
+SP+21:	0 (0x0)
+SP+22:	0 (0x0)
+SP+23:	0 (0x0)
+
+SP+24:	4 (0x4)
+SP+25:	0 (0x0)
+SP+26:	0 (0x0)
+SP+27:	0 (0x0)
+SP+28:	0 (0x0)
+SP+29:	0 (0x0)
+SP+30:	0 (0x0)
+SP+31:	0 (0x0)
+
+SP+32:	1 (0x1)
+SP+33:	0 (0x0)
+SP+34:	0 (0x0)
+SP+35:	0 (0x0)
+
+SP+36:	2 (0x2)
+SP+37:	0 (0x0)
+SP+38:	0 (0x0)
+SP+39:	0 (0x0)
+
+SP+40:	3 (0x3)
+SP+41:	0 (0x0)
+SP+42:	0 (0x0)
+SP+43:	0 (0x0)
+
+SP+44:	5 (0x5)
+SP+45:	0 (0x0)
+SP+46:	0 (0x0)
+SP+47:	0 (0x0)
+```
+
+## Bytes
+
+```
+package main
+
+//go:noinline
+func test_function(a []byte) {}
+
+func main() {
+	test_function([]byte{1, 2, 3, 5})
+}
+```
+
+```
+SP+0:	135 (0x87)
+SP+1:	35 (0x23)
+SP+2:	69 (0x45)
+SP+3:	0 (0x0)
+SP+4:	0 (0x0)
+SP+5:	0 (0x0)
+SP+6:	0 (0x0)
+SP+7:	0 (0x0)
+
+SP+8:	76 (0x4c)
+SP+9:	199 (0xc7)
+SP+10:	4 (0x4)
+SP+11:	0 (0x0)
+SP+12:	192 (0xc0)
+SP+13:	0 (0x0)
+SP+14:	0 (0x0)
+SP+15:	0 (0x0)
+
+SP+16:	4 (0x4)
+SP+17:	0 (0x0)
+SP+18:	0 (0x0)
+SP+19:	0 (0x0)
+SP+20:	0 (0x0)
+SP+21:	0 (0x0)
+SP+22:	0 (0x0)
+SP+23:	0 (0x0)
+
+SP+24:	4 (0x4)
+SP+25:	0 (0x0)
+SP+26:	0 (0x0)
+SP+27:	0 (0x0)
+SP+28:	0 (0x0)
+SP+29:	0 (0x0)
+SP+30:	0 (0x0)
+SP+31:	0 (0x0)
+
+SP+32:	24 (0x18)
+SP+33:	161 (0xa1)
+SP+34:	1 (0x1)
+SP+35:	0 (0x0)
+
+SP+36:	1 (0x1)
+
+SP+37:	2 (0x2)
+
+SP+38:	3 (0x3)
+
+SP+39:	5 (0x5)
+```
+
+```
+package main
+
+//go:noinline
+func test_function(a []byte) {}
+
+func main() {
+	test_function([]byte{5, 6, 7, 8, 9})
+}
+```
+
+```
+SP+0:	146 (0x92)
+SP+1:	35 (0x23)
+SP+2:	69 (0x45)
+SP+3:	0 (0x0)
+SP+4:	0 (0x0)
+SP+5:	0 (0x0)
+SP+6:	0 (0x0)
+SP+7:	0 (0x0)
+
+SP+8:	75 (0x4b)
+SP+9:	199 (0xc7)
+SP+10:	4 (0x4)
+SP+11:	0 (0x0)
+SP+12:	192 (0xc0)
+SP+13:	0 (0x0)
+SP+14:	0 (0x0)
+SP+15:	0 (0x0)
+
+SP+16:	5 (0x5)
+SP+17:	0 (0x0)
+SP+18:	0 (0x0)
+SP+19:	0 (0x0)
+SP+20:	0 (0x0)
+SP+21:	0 (0x0)
+SP+22:	0 (0x0)
+SP+23:	0 (0x0)
+
+SP+24:	5 (0x5)
+SP+25:	0 (0x0)
+SP+26:	0 (0x0)
+SP+27:	0 (0x0)
+SP+28:	0 (0x0)
+SP+29:	0 (0x0)
+SP+30:	0 (0x0)
+SP+31:	0 (0x0)
+
+SP+32:	24 (0x18)
+SP+33:	161 (0xa1)
+SP+34:	1 (0x1)
+
+SP+35:	5 (0x5)
+SP+36:	6 (0x6)
+SP+37:	7 (0x7)
+SP+38:	8 (0x8)
+SP+39:	9 (0x9)
+
+```

--- a/cmd/test-prog/main.go
+++ b/cmd/test-prog/main.go
@@ -1,8 +1,8 @@
 package main
 
 //go:noinline
-func test_function(a string, b byte, x int) {}
+func test_function(int, string) {}
 
 func main() {
-	test_function("grant", byte(1), 7)
+	test_function(3, "hello")
 }

--- a/cmd/test-prog/main.go
+++ b/cmd/test-prog/main.go
@@ -1,8 +1,8 @@
 package main
 
 //go:noinline
-func test_function(int, string) {}
+func test_function(int, [2]int) {}
 
 func main() {
-	test_function(3, "hello")
+	test_function(3, [2]int{1, 2})
 }


### PR DESCRIPTION
I've added array support. Now users can specify arrays at the command line of any other supported data type and will trace results.